### PR TITLE
Process actions properly

### DIFF
--- a/src/db/config.ts
+++ b/src/db/config.ts
@@ -53,7 +53,7 @@ if (environment == 'production') {
   sequelizeConnection = new Sequelize(dbName, dbUser, dbPassword, {
     host: dbHost,
     dialect: dbDriver,
-    logging: false, // environment == 'development'
+    logging: environment == 'development',
   });
 }
 

--- a/src/db/config.ts
+++ b/src/db/config.ts
@@ -13,25 +13,25 @@ if (environment == 'production') {
   // In production we will connect to Postgres using
   // the DATABASE_URL environment variable
   const dbUrl = process.env.DATABASE_URL;
-  if (!dbUrl) throw new Error(`DATABASE_URL environment variable is required to boot in production!`);
+  if (!dbUrl)
+    throw new Error(
+      `DATABASE_URL environment variable is required to boot in production!`
+    );
 
-  sequelizeConnection = new Sequelize(
-    process.env.DATABASE_URL,
-    {
-      dialect: "postgres",
-      dialectOptions: {
-        ssl: {
-          require: true,
-          rejectUnauthorized: false
-        }
+  sequelizeConnection = new Sequelize(process.env.DATABASE_URL, {
+    dialect: 'postgres',
+    dialectOptions: {
+      ssl: {
+        require: true,
+        rejectUnauthorized: false,
       },
-    }
-  );
+    },
+  });
 } else {
-  var dbHost: string;
-  var dbName: string;
-  var dbUser: string;
-  var dbPassword: string;
+  let dbHost: string;
+  let dbName: string;
+  let dbUser: string;
+  let dbPassword: string;
 
   if (environment == 'development') {
     dbHost = process.env.DEV_DB_HOST || 'localhost';
@@ -44,14 +44,16 @@ if (environment == 'production') {
     dbUser = process.env.TEST_DB_USERNAME || 'postgres';
     dbPassword = process.env.TEST_DB_PASSWORD;
   } else {
-    throw new Error(`Invalid NODE_ENV ${environment}, must be one of: [development, test, production]`);
+    throw new Error(
+      `Invalid NODE_ENV ${environment}, must be one of: [development, test, production]`
+    );
   }
 
   const dbDriver: Dialect = 'postgres';
   sequelizeConnection = new Sequelize(dbName, dbUser, dbPassword, {
     host: dbHost,
     dialect: dbDriver,
-    logging: environment == 'development'
+    logging: false, // environment == 'development'
   });
 }
 

--- a/src/graphql/__generated__/resolvers-types.ts
+++ b/src/graphql/__generated__/resolvers-types.ts
@@ -191,7 +191,7 @@ export type GamePieceCoordinatesInput = {
 export type GamePieceMeleeAttackAction = {
   __typename?: 'GamePieceMeleeAttackAction';
   resolved: Scalars['Boolean'];
-  resolvedAttack: ResolvedAttack;
+  resolvedAttack?: Maybe<ResolvedAttack>;
   targetGamePiece: GamePiece;
   totalDamageAverage?: Maybe<Scalars['Float']>;
   totalDamageDealt?: Maybe<Scalars['Int']>;
@@ -217,7 +217,7 @@ export type GamePieceMoveActionInput = {
 export type GamePieceRangedAttackAction = {
   __typename?: 'GamePieceRangedAttackAction';
   resolved: Scalars['Boolean'];
-  resolvedAttack: ResolvedAttack;
+  resolvedAttack?: Maybe<ResolvedAttack>;
   targetGamePiece: GamePiece;
   totalDamageAverage?: Maybe<Scalars['Float']>;
   totalDamageDealt?: Maybe<Scalars['Int']>;
@@ -773,7 +773,7 @@ export type GamePieceMeleeAttackActionResolvers<
 > = ResolversObject<{
   resolved?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   resolvedAttack?: Resolver<
-    ResolversTypes['ResolvedAttack'],
+    Maybe<ResolversTypes['ResolvedAttack']>,
     ParentType,
     ContextType
   >;
@@ -819,7 +819,7 @@ export type GamePieceRangedAttackActionResolvers<
 > = ResolversObject<{
   resolved?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   resolvedAttack?: Resolver<
-    ResolversTypes['ResolvedAttack'],
+    Maybe<ResolversTypes['ResolvedAttack']>,
     ParentType,
     ContextType
   >;

--- a/src/graphql/__generated__/resolvers-types.ts
+++ b/src/graphql/__generated__/resolvers-types.ts
@@ -191,14 +191,14 @@ export type GamePieceCoordinatesInput = {
 export type GamePieceMeleeAttackAction = {
   __typename?: 'GamePieceMeleeAttackAction';
   resolved: Scalars['Boolean'];
-  resolvedAttacks?: Maybe<Array<ResolvedAttack>>;
+  resolvedAttack: ResolvedAttack;
   targetGamePiece: GamePiece;
   totalDamageAverage?: Maybe<Scalars['Float']>;
   totalDamageDealt?: Maybe<Scalars['Int']>;
 };
 
 export type GamePieceMeleeAttackActionInput = {
-  diceRolls: Array<DiceRollInput>;
+  diceRolls: DiceRollInput;
   targetGamePieceId: Scalars['Int'];
 };
 
@@ -217,14 +217,14 @@ export type GamePieceMoveActionInput = {
 export type GamePieceRangedAttackAction = {
   __typename?: 'GamePieceRangedAttackAction';
   resolved: Scalars['Boolean'];
-  resolvedAttacks?: Maybe<Array<ResolvedAttack>>;
+  resolvedAttack: ResolvedAttack;
   targetGamePiece: GamePiece;
   totalDamageAverage?: Maybe<Scalars['Float']>;
   totalDamageDealt?: Maybe<Scalars['Int']>;
 };
 
 export type GamePieceRangedAttackActionInput = {
-  diceRolls: Array<DiceRollInput>;
+  diceRolls: DiceRollInput;
   targetGamePieceId: Scalars['Int'];
 };
 
@@ -772,8 +772,8 @@ export type GamePieceMeleeAttackActionResolvers<
   ParentType extends ResolversParentTypes['GamePieceMeleeAttackAction'] = ResolversParentTypes['GamePieceMeleeAttackAction']
 > = ResolversObject<{
   resolved?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
-  resolvedAttacks?: Resolver<
-    Maybe<Array<ResolversTypes['ResolvedAttack']>>,
+  resolvedAttack?: Resolver<
+    ResolversTypes['ResolvedAttack'],
     ParentType,
     ContextType
   >;
@@ -818,8 +818,8 @@ export type GamePieceRangedAttackActionResolvers<
   ParentType extends ResolversParentTypes['GamePieceRangedAttackAction'] = ResolversParentTypes['GamePieceRangedAttackAction']
 > = ResolversObject<{
   resolved?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
-  resolvedAttacks?: Resolver<
-    Maybe<Array<ResolversTypes['ResolvedAttack']>>,
+  resolvedAttack?: Resolver<
+    ResolversTypes['ResolvedAttack'],
     ParentType,
     ContextType
   >;

--- a/src/graphql/mutations/create_game_piece_actions.ts
+++ b/src/graphql/mutations/create_game_piece_actions.ts
@@ -168,14 +168,12 @@ async function handleRangedAttackAction(
   );
 
   // Create GamePieceAction record in unresolved state
-  const encryptedAttackRolls = rangedAttackInput.diceRolls.map((roll) => {
-    return {
-      publicKey: roll.publicKey,
-      ciphertext: roll.cipherText.split(','),
-      signature: roll.signature,
-      rngPublicKey: process.env.RNG_PUBLIC_KEY,
-    };
-  });
+  const encryptedAttackRolls = {
+    publicKey: rangedAttackInput.diceRolls.publicKey,
+    ciphertext: rangedAttackInput.diceRolls.cipherText.split(','),
+    signature: rangedAttackInput.diceRolls.signature,
+    rngPublicKey: process.env.RNG_PUBLIC_KEY,
+  };
   return await Models.GamePieceAction.create(
     {
       gamePhaseId: gamePhase.id,
@@ -213,14 +211,12 @@ async function handleMeleeAttackAction(
     transaction
   );
 
-  const encryptedAttackRolls = meleeAttackInput.diceRolls.map((roll) => {
-    return {
-      publicKey: roll.publicKey,
-      ciphertext: roll.cipherText.split(','),
-      signature: roll.signature,
-      rngPublicKey: process.env.RNG_PUBLIC_KEY,
-    };
-  });
+  const encryptedAttackRolls = {
+    publicKey: meleeAttackInput.diceRolls.publicKey,
+    ciphertext: meleeAttackInput.diceRolls.cipherText.split(','),
+    signature: meleeAttackInput.diceRolls.signature,
+    rngPublicKey: process.env.RNG_PUBLIC_KEY,
+  };
   return await Models.GamePieceAction.create(
     {
       gamePhaseId: gamePhase.id,

--- a/src/graphql/schema.graphql
+++ b/src/graphql/schema.graphql
@@ -167,7 +167,7 @@ type GamePieceMoveAction {
 type GamePieceRangedAttackAction {
   targetGamePiece: GamePiece!
   resolved: Boolean!
-  resolvedAttack: ResolvedAttack!
+  resolvedAttack: ResolvedAttack
   totalDamageDealt: Int
   totalDamageAverage: Float
 }
@@ -175,7 +175,7 @@ type GamePieceRangedAttackAction {
 type GamePieceMeleeAttackAction {
   targetGamePiece: GamePiece!
   resolved: Boolean!
-  resolvedAttack: ResolvedAttack!
+  resolvedAttack: ResolvedAttack
   totalDamageDealt: Int
   totalDamageAverage: Float
 }

--- a/src/graphql/schema.graphql
+++ b/src/graphql/schema.graphql
@@ -167,7 +167,7 @@ type GamePieceMoveAction {
 type GamePieceRangedAttackAction {
   targetGamePiece: GamePiece!
   resolved: Boolean!
-  resolvedAttacks: [ResolvedAttack!]
+  resolvedAttack: ResolvedAttack!
   totalDamageDealt: Int
   totalDamageAverage: Float
 }
@@ -175,7 +175,7 @@ type GamePieceRangedAttackAction {
 type GamePieceMeleeAttackAction {
   targetGamePiece: GamePiece!
   resolved: Boolean!
-  resolvedAttacks: [ResolvedAttack!]
+  resolvedAttack: ResolvedAttack!
   totalDamageDealt: Int
   totalDamageAverage: Float
 }
@@ -252,12 +252,12 @@ input GamePieceCoordinatesInput {
 
 input GamePieceRangedAttackActionInput {
   targetGamePieceId: Int!
-  diceRolls: [DiceRollInput!]!
+  diceRolls: DiceRollInput!
 }
 
 input GamePieceMeleeAttackActionInput {
   targetGamePieceId: Int!
-  diceRolls: [DiceRollInput!]!
+  diceRolls: DiceRollInput!
 }
 
 input DiceRollInput {

--- a/src/models/game_piece_action.ts
+++ b/src/models/game_piece_action.ts
@@ -23,8 +23,8 @@ export type GamePieceRangedAttackAction = {
   actionType: 'rangedAttack';
   resolved: boolean;
   targetGamePieceId: number;
-  encryptedAttackRolls: EncrytpedAttackRollJSON[];
-  resolvedAttacks?: ResolvedAttack[];
+  encryptedAttackRolls: EncrytpedAttackRollJSON;
+  resolvedAttack?: ResolvedAttack;
   totalDamageDealt?: number;
   totalDamageAverage?: number;
 };
@@ -32,8 +32,8 @@ export type GamePieceMeleeAttackAction = {
   actionType: 'meleeAttack';
   resolved: boolean;
   targetGamePieceId: number;
-  encryptedAttackRolls: EncrytpedAttackRollJSON[];
-  resolvedAttacks?: ResolvedAttack[];
+  encryptedAttackRolls: EncrytpedAttackRollJSON;
+  resolvedAttack?: ResolvedAttack;
   totalDamageDealt?: number;
   totalDamageAverage?: number;
 };

--- a/src/service_objects/game_piece_action_resolvers/attack_resolver.ts
+++ b/src/service_objects/game_piece_action_resolvers/attack_resolver.ts
@@ -9,81 +9,73 @@ import dotenv from 'dotenv';
 
 dotenv.config();
 
-export default function resolveAttacks(
+export default function resolveAttack(
   numAttacks: number,
   attackerHitRollStat: number,
   attackerWoundRollStat: number,
   targetSaveRollStat: number,
   attackerArmorPiercingStat: number,
   attackerDamageStat: number,
-  attackRolls: EncrytpedAttackRollJSON[]
-): ResolvedAttack[] {
+  attackRolls: EncrytpedAttackRollJSON
+): ResolvedAttack {
   console.log('$$$', 'Resolving...');
   const serverPrivateKey = PrivateKey.fromBase58(
     process.env.SERVER_PRIVATE_KEY
   );
-  const decryptedAttackRolls = attackRolls.map((roll) => {
-    console.log('$$$', 'Roll:', roll);
-    const snarkyRoll = new EncrytpedAttackRoll({
-      publicKey: Group.fromJSON(roll.publicKey),
-      ciphertext: roll.ciphertext.map((c) => Field(c)),
-      signature: Signature.fromJSON(roll.signature),
-      rngPublicKey: PublicKey.fromBase58(roll.rngPublicKey),
-    });
-
-    return snarkyRoll.decryptRoll(serverPrivateKey);
+  console.log('$$$', 'Roll:', attackRolls);
+  const snarkyRoll = new EncrytpedAttackRoll({
+    publicKey: Group.fromJSON(attackRolls.publicKey),
+    ciphertext: attackRolls.ciphertext.map((c) => Field(c)),
+    signature: Signature.fromJSON(attackRolls.signature),
+    rngPublicKey: PublicKey.fromBase58(attackRolls.rngPublicKey),
   });
+  const decryptedAttackRolls = snarkyRoll.decryptRoll(serverPrivateKey);
 
   console.log('$$$', 'Decrypted rolls:', decryptedAttackRolls);
 
   // Gather details of each attack and determine damage
-  let attacks = [];
-  for (let i = 0; i < numAttacks; i++) {
-    const hitRoll = Number(decryptedAttackRolls[i].hit.toString());
-    const woundRoll = Number(decryptedAttackRolls[i].wound.toString());
-    const saveRoll = Number(decryptedAttackRolls[i].save.toString());
+  const hitRoll = Number(decryptedAttackRolls.hit.toString());
+  const woundRoll = Number(decryptedAttackRolls.wound.toString());
+  const saveRoll = Number(decryptedAttackRolls.save.toString());
 
-    const hitRollSuccess = hitRoll >= attackerHitRollStat;
-    const woundRollSuccess = woundRoll >= attackerWoundRollStat;
+  const hitRollSuccess = hitRoll >= attackerHitRollStat;
+  const woundRollSuccess = woundRoll >= attackerWoundRollStat;
 
-    const armorPiercing = attackerArmorPiercingStat || 0;
-    const modifiedSave = targetSaveRollStat + armorPiercing;
-    const saveRollSuccess = saveRoll >= modifiedSave;
+  const armorPiercing = attackerArmorPiercingStat || 0;
+  const modifiedSave = targetSaveRollStat + armorPiercing;
+  const saveRollSuccess = saveRoll >= modifiedSave;
 
-    const damageDealt =
-      hitRollSuccess && woundRollSuccess && !saveRollSuccess
-        ? attackerDamageStat
-        : 0;
+  const damageDealt =
+    hitRollSuccess && woundRollSuccess && !saveRollSuccess
+      ? attackerDamageStat
+      : 0;
 
-    const oddsOfHitting = (7 - attackerHitRollStat) / 6;
-    const oddsOfWounding = (7 - attackerWoundRollStat) / 6;
-    const oddsOfPassingArmorSave = Math.max(7 - modifiedSave, 0) / 6;
-    const averageDamage =
-      oddsOfHitting *
-      oddsOfWounding *
-      (1 - oddsOfPassingArmorSave) *
-      attackerDamageStat;
+  const oddsOfHitting = (7 - attackerHitRollStat) / 6;
+  const oddsOfWounding = (7 - attackerWoundRollStat) / 6;
+  const oddsOfPassingArmorSave = Math.max(7 - modifiedSave, 0) / 6;
+  const averageDamage =
+    oddsOfHitting *
+    oddsOfWounding *
+    (1 - oddsOfPassingArmorSave) *
+    attackerDamageStat;
 
-    attacks.push({
-      hitRoll: {
-        roll: hitRoll,
-        rollNeeded: attackerHitRollStat,
-        success: hitRollSuccess,
-      },
-      woundRoll: {
-        roll: woundRoll,
-        rollNeeded: attackerWoundRollStat,
-        success: woundRollSuccess,
-      },
-      saveRoll: {
-        roll: saveRoll,
-        rollNeeded: modifiedSave,
-        success: saveRollSuccess,
-      },
-      damageDealt: damageDealt,
-      averageDamage: averageDamage,
-    });
-    console.log('$$$', 'Attack:', attacks);
-  }
-  return attacks;
+  return {
+    hitRoll: {
+      roll: hitRoll,
+      rollNeeded: attackerHitRollStat,
+      success: hitRollSuccess,
+    },
+    woundRoll: {
+      roll: woundRoll,
+      rollNeeded: attackerWoundRollStat,
+      success: woundRollSuccess,
+    },
+    saveRoll: {
+      roll: saveRoll,
+      rollNeeded: modifiedSave,
+      success: saveRollSuccess,
+    },
+    damageDealt: damageDealt,
+    averageDamage: averageDamage,
+  };
 }

--- a/src/service_objects/game_piece_action_resolvers/ranged_attack_resolver.ts
+++ b/src/service_objects/game_piece_action_resolvers/ranged_attack_resolver.ts
@@ -1,5 +1,5 @@
 import * as Models from '../../models/index.js';
-import resolveAttacks from './attack_resolver.js';
+import resolveAttack from './attack_resolver.js';
 import { Transaction } from 'sequelize';
 import serializePiecesTree from '../mina/pieces_tree_serializer.js';
 import serializeArenaTree from '../mina/arena_tree_serializer.js';
@@ -13,6 +13,7 @@ import {
   Group,
 } from 'snarkyjs';
 import dotenv from 'dotenv';
+import { type GamePieceRangedAttackAction } from '../../models/game_piece_action.js';
 
 dotenv.config();
 
@@ -157,48 +158,45 @@ export default async function resolveRangedAttackAction(
       process.env.SERVER_PRIVATE_KEY
     );
 
-    // For each attack, attempt to apply the attack action
-    for (let i = 0; i < attackRolls.length; i++) {
-      const roll = new EncrytpedAttackRoll({
-        publicKey: Group.fromJSON(attackRolls[i].publicKey),
-        ciphertext: attackRolls[i].ciphertext.map((c) => Field(c)),
-        signature: Signature.fromJSON(attackRolls[i].signature),
-        rngPublicKey: PublicKey.fromBase58(attackRolls[i].rngPublicKey),
-      });
-      const piecesTreeAfterAttack = startingGamePiecesTree.clone();
-      piecesTreeAfterAttack.set(
-        snarkyTargetPiece.id.toBigInt(),
-        snarkyTargetPiece.hash()
-      );
+    const roll = new EncrytpedAttackRoll({
+      publicKey: Group.fromJSON(attackRolls.publicKey),
+      ciphertext: attackRolls.ciphertext.map((c) => Field(c)),
+      signature: Signature.fromJSON(attackRolls.signature),
+      rngPublicKey: PublicKey.fromBase58(attackRolls.rngPublicKey),
+    });
+    const piecesTreeAfterAttack = startingGamePiecesTree.clone();
+    piecesTreeAfterAttack.set(
+      snarkyTargetPiece.id.toBigInt(),
+      snarkyTargetPiece.hash()
+    );
 
-      stateAfterAttack = snarkyGameState.applyRangedAttackAction(
-        snarkyAction,
-        Signature.fromJSON(action.signature),
-        snarkyAttackingPiece,
-        snarkyTargetPiece,
-        startingGamePiecesTree.getWitness(snarkyAttackingPiece.id.toBigInt()),
-        startingGamePiecesTree.getWitness(snarkyTargetPiece.id.toBigInt()),
-        UInt32.from(
-          Math.floor(
-            attackingGamePiece.distanceTo(targetGamePiece.coordinates())
-          )
-        ),
-        roll,
-        serverPrivateKey
-      );
-    }
+    stateAfterAttack = snarkyGameState.applyRangedAttackAction(
+      snarkyAction,
+      Signature.fromJSON(action.signature),
+      snarkyAttackingPiece,
+      snarkyTargetPiece,
+      startingGamePiecesTree.getWitness(snarkyAttackingPiece.id.toBigInt()),
+      startingGamePiecesTree.getWitness(snarkyTargetPiece.id.toBigInt()),
+      UInt32.from(
+        Math.floor(attackingGamePiece.distanceTo(targetGamePiece.coordinates()))
+      ),
+      roll,
+      serverPrivateKey
+    );
     snarkySuccess = true;
     console.log(
       `Successfully applied snarky ranged attack action ${JSON.stringify(
         actionData
-      )} to game ${attackingGamePiece.gameId} attacking piece ${attackingGamePiece.id
+      )} to game ${attackingGamePiece.gameId} attacking piece ${
+        attackingGamePiece.id
       }, target piece ${targetGamePiece.id}`
     );
   } catch (e) {
     console.warn(
       `Unable to apply snarky ranged attack action ${JSON.stringify(
         actionData
-      )} to game ${attackingGamePiece.gameId} attacking piece ${attackingGamePiece.id
+      )} to game ${attackingGamePiece.gameId} attacking piece ${
+        attackingGamePiece.id
       }, target piece ${targetGamePiece.id} - ${e}`
     );
   }
@@ -211,10 +209,10 @@ export default async function resolveRangedAttackAction(
     ap: attackingUnit.rangedArmorPiercing,
     dmg: attackingUnit.rangedDamage,
   });
-  // Resolve attack sequence
-  let resolvedAttacks;
+  // Resolve attack
+  let resolvedAttack;
   try {
-    resolvedAttacks = resolveAttacks(
+    resolvedAttack = resolveAttack(
       attackingUnit.rangedNumAttacks,
       attackingUnit.rangedHitRoll,
       attackingUnit.rangedWoundRoll,
@@ -228,14 +226,8 @@ export default async function resolveRangedAttackAction(
     throw e;
   }
   console.log('$$', 'Resolved');
-  const totalDamageDealt = resolvedAttacks.reduce(
-    (sum, attack) => sum + attack.damageDealt,
-    0
-  );
-  const totalDamageAverage = resolvedAttacks.reduce(
-    (sum, attack) => sum + attack.averageDamage,
-    0
-  );
+  const totalDamageDealt = resolvedAttack.damageDealt;
+  const totalDamageAverage = resolvedAttack.averageDamage;
   console.log('$$', 'Damage', totalDamageDealt, totalDamageAverage);
 
   // Update target GamePiece with damage dealt
@@ -249,9 +241,11 @@ export default async function resolveRangedAttackAction(
 
   console.log('$$', 'Updating Action to be Resolved');
   // Update action record as resolved
-  let newActionData = JSON.parse(JSON.stringify(actionData));
+  let newActionData = JSON.parse(
+    JSON.stringify(actionData)
+  ) as GamePieceRangedAttackAction;
   newActionData.resolved = true;
-  newActionData.resolvedAttacks = resolvedAttacks;
+  newActionData.resolvedAttack = resolvedAttack;
   newActionData.totalDamageDealt = totalDamageDealt;
   newActionData.totalDamageAverage = totalDamageAverage;
   action.actionData = newActionData;

--- a/src/service_objects/game_piece_action_resolvers/ranged_attack_resolver.ts
+++ b/src/service_objects/game_piece_action_resolvers/ranged_attack_resolver.ts
@@ -222,7 +222,7 @@ export default async function resolveRangedAttackAction(
       attackRolls
     );
   } catch (e) {
-    console.log(e);
+    console.log('$$$', e);
     throw e;
   }
   console.log('$$', 'Resolved');

--- a/test/service_objects/game_piece_action_resolvers/attack_resolver.test.ts
+++ b/test/service_objects/game_piece_action_resolvers/attack_resolver.test.ts
@@ -9,7 +9,7 @@ describe('resolveAttack', () => {
   let targetSaveRollStat: number;
   let attackerArmorPiercingStat: number;
   let attackerDamageStat: number;
-  let encryptedAttackRolls: EncrytpedAttackRollJSON[];
+  let encryptedAttackRoll: EncrytpedAttackRollJSON;
 
   beforeEach(async () => {
     numAttacks = 100;
@@ -19,67 +19,64 @@ describe('resolveAttack', () => {
     attackerArmorPiercingStat = 1;
     attackerDamageStat = 1;
 
-    encryptedAttackRolls = new Array(numAttacks).fill(roll_6_6_1);
+    encryptedAttackRoll = roll_6_6_1;
   });
 
   it('resolves attack sequences correctly', async () => {
-    const resolvedAttacks = resolveAttack(
+    const resolvedAttack = resolveAttack(
       numAttacks,
       attackerHitRollStat,
       attackerWoundRollStat,
       targetSaveRollStat,
       attackerArmorPiercingStat,
       attackerDamageStat,
-      encryptedAttackRolls
+      encryptedAttackRoll
     );
-    expect(resolvedAttacks.length).toBe(numAttacks);
-    resolvedAttacks.forEach((resolvedAttack) => {
-      expect(resolvedAttack.hitRoll.rollNeeded).toBe(attackerHitRollStat);
-      expect(resolvedAttack.woundRoll.rollNeeded).toBe(attackerWoundRollStat);
-      expect(resolvedAttack.saveRoll.rollNeeded).toBe(
-        targetSaveRollStat + attackerArmorPiercingStat
-      );
+    expect(resolvedAttack.hitRoll.rollNeeded).toBe(attackerHitRollStat);
+    expect(resolvedAttack.woundRoll.rollNeeded).toBe(attackerWoundRollStat);
+    expect(resolvedAttack.saveRoll.rollNeeded).toBe(
+      targetSaveRollStat + attackerArmorPiercingStat
+    );
 
-      const oddsOfHitting = (7 - attackerHitRollStat) / 6;
-      const oddsOfWounding = (7 - attackerWoundRollStat) / 6;
-      const modifiedSave = targetSaveRollStat + attackerArmorPiercingStat;
-      const oddsOfPassingArmorSave = Math.max(7 - modifiedSave, 0) / 6;
-      const expectedAverageDamage = (
-        oddsOfHitting *
-        oddsOfWounding *
-        (1 - oddsOfPassingArmorSave) *
-        attackerDamageStat
-      ).toFixed(2);
-      expect(resolvedAttack.averageDamage).toBe(expectedAverageDamage);
+    const oddsOfHitting = (7 - attackerHitRollStat) / 6;
+    const oddsOfWounding = (7 - attackerWoundRollStat) / 6;
+    const modifiedSave = targetSaveRollStat + attackerArmorPiercingStat;
+    const oddsOfPassingArmorSave = Math.max(7 - modifiedSave, 0) / 6;
+    const expectedAverageDamage = (
+      oddsOfHitting *
+      oddsOfWounding *
+      (1 - oddsOfPassingArmorSave) *
+      attackerDamageStat
+    ).toFixed(2);
+    expect(resolvedAttack.averageDamage.toFixed(2)).toBe(expectedAverageDamage);
 
-      if (resolvedAttack.hitRoll.roll >= attackerHitRollStat) {
-        expect(resolvedAttack.hitRoll.success).toBe(true);
-      } else {
-        expect(resolvedAttack.hitRoll.success).toBe(false);
-        expect(resolvedAttack.damageDealt).toBe(0);
-      }
-      if (resolvedAttack.woundRoll.roll >= attackerWoundRollStat) {
-        expect(resolvedAttack.woundRoll.success).toBe(true);
-      } else {
-        expect(resolvedAttack.woundRoll.success).toBe(false);
-        expect(resolvedAttack.damageDealt).toBe(0);
-      }
-      if (
-        resolvedAttack.saveRoll.roll >=
-        targetSaveRollStat + attackerArmorPiercingStat
-      ) {
-        expect(resolvedAttack.saveRoll.success).toBe(true);
-        expect(resolvedAttack.damageDealt).toBe(0);
-      } else {
-        expect(resolvedAttack.saveRoll.success).toBe(false);
-      }
-      if (
-        resolvedAttack.hitRoll.success &&
-        resolvedAttack.woundRoll.success &&
-        !resolvedAttack.saveRoll.success
-      ) {
-        expect(resolvedAttack.damageDealt).toBe(attackerDamageStat);
-      }
-    });
+    if (resolvedAttack.hitRoll.roll >= attackerHitRollStat) {
+      expect(resolvedAttack.hitRoll.success).toBe(true);
+    } else {
+      expect(resolvedAttack.hitRoll.success).toBe(false);
+      expect(resolvedAttack.damageDealt).toBe(0);
+    }
+    if (resolvedAttack.woundRoll.roll >= attackerWoundRollStat) {
+      expect(resolvedAttack.woundRoll.success).toBe(true);
+    } else {
+      expect(resolvedAttack.woundRoll.success).toBe(false);
+      expect(resolvedAttack.damageDealt).toBe(0);
+    }
+    if (
+      resolvedAttack.saveRoll.roll >=
+      targetSaveRollStat + attackerArmorPiercingStat
+    ) {
+      expect(resolvedAttack.saveRoll.success).toBe(true);
+      expect(resolvedAttack.damageDealt).toBe(0);
+    } else {
+      expect(resolvedAttack.saveRoll.success).toBe(false);
+    }
+    if (
+      resolvedAttack.hitRoll.success &&
+      resolvedAttack.woundRoll.success &&
+      !resolvedAttack.saveRoll.success
+    ) {
+      expect(resolvedAttack.damageDealt).toBe(attackerDamageStat);
+    }
   });
 });

--- a/test/service_objects/game_piece_action_resolvers/melee_attack_resolver.test.ts
+++ b/test/service_objects/game_piece_action_resolvers/melee_attack_resolver.test.ts
@@ -198,8 +198,8 @@ describe('resolveMeleeAttackAction', () => {
         actionType: 'meleeAttack',
         resolved: false,
         targetGamePieceId: targetGamePiece.id,
-        encryptedAttackRolls: [roll_6_6_1, roll_1_6_1, roll_6_1_1],
-        resolvedAttacks: undefined,
+        encryptedAttackRolls: roll_6_6_1,
+        resolvedAttack: undefined,
       },
       signature: signature.toJSON(),
     });
@@ -219,29 +219,14 @@ describe('resolveMeleeAttackAction', () => {
       // Check action to now be resolved with saved results
       await action.reload();
       expect(action.actionData['resolved']).toBe(true);
-      let savedResolvedAttacks = action.actionData['resolvedAttacks'];
-      expect(savedResolvedAttacks.length).toBe(3);
-      expect(savedResolvedAttacks[0].hitRoll.roll).toBe(6);
-      expect(savedResolvedAttacks[0].hitRoll.success).toBe(true);
-      expect(savedResolvedAttacks[0].woundRoll.roll).toBe(6);
-      expect(savedResolvedAttacks[0].woundRoll.success).toBe(true);
-      expect(savedResolvedAttacks[0].saveRoll.roll).toBe(1);
-      expect(savedResolvedAttacks[0].saveRoll.success).toBe(false);
-      expect(savedResolvedAttacks[0].damageDealt).toBe(1);
-      expect(savedResolvedAttacks[1].hitRoll.roll).toBe(1);
-      expect(savedResolvedAttacks[1].hitRoll.success).toBe(false);
-      expect(savedResolvedAttacks[1].woundRoll.roll).toBe(6);
-      expect(savedResolvedAttacks[1].woundRoll.success).toBe(true);
-      expect(savedResolvedAttacks[1].saveRoll.roll).toBe(1);
-      expect(savedResolvedAttacks[1].saveRoll.success).toBe(false);
-      expect(savedResolvedAttacks[1].damageDealt).toBe(0);
-      expect(savedResolvedAttacks[2].hitRoll.roll).toBe(6);
-      expect(savedResolvedAttacks[2].hitRoll.success).toBe(true);
-      expect(savedResolvedAttacks[2].woundRoll.roll).toBe(1);
-      expect(savedResolvedAttacks[2].woundRoll.success).toBe(false);
-      expect(savedResolvedAttacks[2].saveRoll.roll).toBe(1);
-      expect(savedResolvedAttacks[2].saveRoll.success).toBe(false);
-      expect(savedResolvedAttacks[2].damageDealt).toBe(0);
+      let savedResolvedAttack = action.actionData['resolvedAttack'];
+      expect(savedResolvedAttack.hitRoll.roll).toBe(6);
+      expect(savedResolvedAttack.hitRoll.success).toBe(true);
+      expect(savedResolvedAttack.woundRoll.roll).toBe(6);
+      expect(savedResolvedAttack.woundRoll.success).toBe(true);
+      expect(savedResolvedAttack.saveRoll.roll).toBe(1);
+      expect(savedResolvedAttack.saveRoll.success).toBe(false);
+      expect(savedResolvedAttack.damageDealt).toBe(1);
 
       expect(action.actionData['totalDamageDealt']).toBe(1);
 

--- a/test/service_objects/game_piece_action_resolvers/ranged_attack_resolver.test.ts
+++ b/test/service_objects/game_piece_action_resolvers/ranged_attack_resolver.test.ts
@@ -179,8 +179,8 @@ describe('resolveRangedAttackAction', () => {
         actionType: 'rangedAttack',
         resolved: false,
         targetGamePieceId: targetGamePiece.id,
-        encryptedAttackRolls: [roll_6_6_1, roll_6_6_1, roll_6_6_1],
-        resolvedAttacks: undefined,
+        encryptedAttackRolls: roll_6_6_1,
+        resolvedAttack: undefined,
       },
     });
   });
@@ -199,21 +199,20 @@ describe('resolveRangedAttackAction', () => {
       // Check action to now be resolved with saved results
       await action.reload();
       expect(action.actionData['resolved']).toBe(true);
-      let savedResolvedAttacks = action.actionData['resolvedAttacks'];
-      expect(savedResolvedAttacks.length).toBe(3);
-      expect(savedResolvedAttacks[0].hitRoll.roll).toBe(6);
-      expect(savedResolvedAttacks[0].hitRoll.success).toBe(true);
-      expect(savedResolvedAttacks[0].woundRoll.roll).toBe(6);
-      expect(savedResolvedAttacks[0].woundRoll.success).toBe(true);
-      expect(savedResolvedAttacks[0].saveRoll.roll).toBe(1);
-      expect(savedResolvedAttacks[0].saveRoll.success).toBe(false);
-      expect(savedResolvedAttacks[0].damageDealt).toBe(1);
+      let savedResolvedAttack = action.actionData['resolvedAttack'];
+      expect(savedResolvedAttack.hitRoll.roll).toBe(6);
+      expect(savedResolvedAttack.hitRoll.success).toBe(true);
+      expect(savedResolvedAttack.woundRoll.roll).toBe(6);
+      expect(savedResolvedAttack.woundRoll.success).toBe(true);
+      expect(savedResolvedAttack.saveRoll.roll).toBe(1);
+      expect(savedResolvedAttack.saveRoll.success).toBe(false);
+      expect(savedResolvedAttack.damageDealt).toBe(1);
 
-      expect(action.actionData['totalDamageDealt']).toBe(3);
+      expect(action.actionData['totalDamageDealt']).toBe(1);
 
       // Check targetGamePiece new health
       await targetGamePiece.reload();
-      expect(targetGamePiece.health).toBe(0);
+      expect(targetGamePiece.health).toBe(2);
     });
   });
 


### PR DESCRIPTION
## Problem

The proof system can only run a single attack at a time, so an `Action` is one attack.  On the backend, a `GamePieceAction` may have multiple attacks, and the logic for resolving them reduces many attacks into one net result in the resolved game piece action.

This was fine until now that I am trying to incorporate the player signing their actions.  The column `signature` on a `GamePieceAction` is a proof system artifact, which comes from the user signing their action payload so the proof can authenticate the origin.  The impossibility lies in a single action signature encompassing multiple dice rolls.

## Solution

The API, conveniently, allows for a phase to submit an array of actions, with no further validations.  This mirrors the proof system, which for now would not actually disallow one piece from acting multiple times in a phase.  This is by design specifically for the use case of applying multiple attacks in one phase.  My proposed solution, implemented here, takes advantage of this, and simply makes all references to attacks singular.  The new way to handle multiple attacks will be to submit each one as a separate action.  Each action can now have one signature, and it will work with the proof.

## Notes

An alternative I explored was a migration such that a `GamePieceAction` can have multiple signatures, to match the multiple attacks.  This would require a migration, changes to the graphQL schema, and be brittle (arrays of different lengths).  I hope you agree that's a much worse option.

I apologize for the oversight in letting this design stand for so long.  I think my changes here and in the frontend break very little, but it does break the phase summary.  The break is not total, but only in the aggregation of one piece's attacks.  There is now no sum of attacks by piece to reference.  I think that can be re-implemented in the frontend easily enough, but it sucks that we have to include a breaking change.
