### PR TITLE
sketching out game proof

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
 NEW_RELIC_LICENSE_KEY=...
 NODE_ENV=development
 DB_LOGGING=true
+COMPILE_PROOFS=false
 
 DEV_DB_HOST=localhost
 DEV_DB_NAME=mina_arena_development

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "dotenv": "^16.0.3",
         "express": "^4.18.2",
         "http": "^0.0.1-security",
-        "mina-arena-contracts": "^0.4.3-beta5",
+        "mina-arena-contracts": "^0.4.3",
         "newrelic": "^10.3.0",
         "pg": "^8.9.0",
         "sequelize": "^6.31.0"
@@ -9523,9 +9523,9 @@
       }
     },
     "node_modules/mina-arena-contracts": {
-      "version": "0.4.3-beta5",
-      "resolved": "https://registry.npmjs.org/mina-arena-contracts/-/mina-arena-contracts-0.4.3-beta5.tgz",
-      "integrity": "sha512-o/j1LXbDtQAmxRTJUJmQAa7aBtHGidiVit+FgQYwXQfguJNqHNwWTjdMGi/77bvWEewdR8b1n2dGcUTEGdkQqA==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/mina-arena-contracts/-/mina-arena-contracts-0.4.3.tgz",
+      "integrity": "sha512-xndx0QFW5lIIDit2tEttE2DcTl+xmNLpZvFdgpoS6rYiTzXpHFyOU/FHExkVVi+Y29GiP7WIXaPABoNNfomyhw==",
       "peerDependencies": {
         "snarkyjs": "^0.11.4"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,12 +11,14 @@
       "dependencies": {
         "@apollo/server": "^4.4.0",
         "@newrelic/apollo-server-plugin": "^3.1.0",
+        "@types/axios": "^0.14.0",
         "@types/express": "^4.17.17",
+        "axios": "^1.4.0",
         "cors": "^2.8.5",
         "dotenv": "^16.0.3",
         "express": "^4.18.2",
         "http": "^0.0.1-security",
-        "mina-arena-contracts": "^0.4.2",
+        "mina-arena-contracts": "^0.4.3-beta5",
         "newrelic": "^10.3.0",
         "pg": "^8.9.0",
         "sequelize": "^6.31.0"
@@ -3870,6 +3872,14 @@
         "ws": "^7.5.9"
       }
     },
+    "node_modules/@newrelic/security-agent/node_modules/axios": {
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "dependencies": {
+        "follow-redirects": "^1.14.0"
+      }
+    },
     "node_modules/@newrelic/security-agent/node_modules/semver": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
@@ -4131,6 +4141,15 @@
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
       "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
       "dev": true
+    },
+    "node_modules/@types/axios": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@types/axios/-/axios-0.14.0.tgz",
+      "integrity": "sha512-KqQnQbdYE54D7oa/UmYVMZKq7CO4l8DEENzOKc4aBRwxCXSlJXGz83flFx5L7AWrOQnmuN3kVsRdt+GZPPjiVQ==",
+      "deprecated": "This is a stub types definition for axios (https://github.com/mzabriskie/axios). axios provides its own type definitions, so you don't need @types/axios installed!",
+      "dependencies": {
+        "axios": "*"
+      }
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.0",
@@ -5009,11 +5028,26 @@
       }
     },
     "node_modules/axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz",
+      "integrity": "sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==",
       "dependencies": {
-        "follow-redirects": "^1.14.0"
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/babel-jest": {
@@ -9489,9 +9523,9 @@
       }
     },
     "node_modules/mina-arena-contracts": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/mina-arena-contracts/-/mina-arena-contracts-0.4.2.tgz",
-      "integrity": "sha512-iSb6Gngjmq8rkZ+tN7S4ipLKYLGZGJvAgnIJlpq/lzpxGSATXLRObaCG8129b/6eN9R1S9CRahH6KaQJQD97pA==",
+      "version": "0.4.3-beta5",
+      "resolved": "https://registry.npmjs.org/mina-arena-contracts/-/mina-arena-contracts-0.4.3-beta5.tgz",
+      "integrity": "sha512-o/j1LXbDtQAmxRTJUJmQAa7aBtHGidiVit+FgQYwXQfguJNqHNwWTjdMGi/77bvWEewdR8b1n2dGcUTEGdkQqA==",
       "peerDependencies": {
         "snarkyjs": "^0.11.4"
       }
@@ -10331,6 +10365,11 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/pseudomap": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -25,12 +25,14 @@
   "dependencies": {
     "@apollo/server": "^4.4.0",
     "@newrelic/apollo-server-plugin": "^3.1.0",
+    "@types/axios": "^0.14.0",
     "@types/express": "^4.17.17",
+    "axios": "^1.4.0",
     "cors": "^2.8.5",
     "dotenv": "^16.0.3",
     "express": "^4.18.2",
     "http": "^0.0.1-security",
-    "mina-arena-contracts": "^0.4.2",
+    "mina-arena-contracts": "^0.4.3-beta5",
     "newrelic": "^10.3.0",
     "pg": "^8.9.0",
     "sequelize": "^6.31.0"

--- a/package.json
+++ b/package.json
@@ -31,8 +31,7 @@
     "cors": "^2.8.5",
     "dotenv": "^16.0.3",
     "express": "^4.18.2",
-    "http": "^0.0.1-security",
-    "mina-arena-contracts": "^0.4.3-beta5",
+    "mina-arena-contracts": "^0.4.3",
     "newrelic": "^10.3.0",
     "pg": "^8.9.0",
     "sequelize": "^6.31.0"

--- a/src/app.ts
+++ b/src/app.ts
@@ -17,14 +17,6 @@ import { GameProgram, PhaseProgram, TurnProgram } from 'mina-arena-contracts';
 
 dotenv.config();
 
-if (process.env.COMPILE_PROOFS === 'true') {
-  console.time('compiling proofs');
-  await PhaseProgram.compile();
-  await TurnProgram.compile();
-  await GameProgram.compile();
-  console.timeEnd('compiling proofs');
-}
-
 dbInit();
 
 const app = express();

--- a/src/app.ts
+++ b/src/app.ts
@@ -12,11 +12,6 @@ import resolvers from './graphql/resolvers.js';
 
 import dbInit from './db/init.js';
 
-import dotenv from 'dotenv';
-import { GameProgram, PhaseProgram, TurnProgram } from 'mina-arena-contracts';
-
-dotenv.config();
-
 dbInit();
 
 const app = express();

--- a/src/app.ts
+++ b/src/app.ts
@@ -12,6 +12,19 @@ import resolvers from './graphql/resolvers.js';
 
 import dbInit from './db/init.js';
 
+import dotenv from 'dotenv';
+import { GameProgram, PhaseProgram, TurnProgram } from 'mina-arena-contracts';
+
+dotenv.config();
+
+if (process.env.COMPILE_PROOFS === 'true') {
+  console.time('compiling proofs');
+  PhaseProgram.compile();
+  TurnProgram.compile();
+  GameProgram.compile();
+  console.timeEnd('compiling proofs');
+}
+
 dbInit();
 
 const app = express();

--- a/src/app.ts
+++ b/src/app.ts
@@ -19,9 +19,9 @@ dotenv.config();
 
 if (process.env.COMPILE_PROOFS === 'true') {
   console.time('compiling proofs');
-  PhaseProgram.compile();
-  TurnProgram.compile();
-  GameProgram.compile();
+  await PhaseProgram.compile();
+  await TurnProgram.compile();
+  await GameProgram.compile();
   console.timeEnd('compiling proofs');
 }
 

--- a/src/db/migrations/20230721030154-save-proofs.js
+++ b/src/db/migrations/20230721030154-save-proofs.js
@@ -1,0 +1,50 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    const transaction = await queryInterface.sequelize.transaction();
+    try {
+      await queryInterface.addColumn(
+        'Games',
+        'gameProof',
+        { type: Sequelize.JSONB, allowNull: true, defaultValue: null },
+        { transaction }
+      );
+      await queryInterface.addColumn(
+        'GamePhases',
+        'turnProof',
+        { type: Sequelize.JSONB, allowNull: true, defaultValue: null },
+        { transaction }
+      );
+      await queryInterface.addColumn(
+        'GamePhases',
+        'phaseProof',
+        { type: Sequelize.JSONB, allowNull: true, defaultValue: null },
+        { transaction }
+      );
+      await transaction.commit();
+    } catch (err) {
+      await transaction.rollback();
+      throw err;
+    }
+  },
+
+  async down(queryInterface, Sequelize) {
+    const transaction = await queryInterface.sequelize.transaction();
+    try {
+      await queryInterface.removeColumn('Games', 'gameProof', {
+        transaction,
+      });
+      await queryInterface.removeColumn('GamePhases', 'turnProof', {
+        transaction,
+      });
+      await queryInterface.removeColumn('GamePhases', 'phaseProof', {
+        transaction,
+      });
+    } catch (err) {
+      // await transaction.rollback();
+      console.error(err);
+    }
+  },
+};

--- a/src/graphql/mutations/start_game.ts
+++ b/src/graphql/mutations/start_game.ts
@@ -2,7 +2,6 @@ import * as Types from '../__generated__/resolvers-types';
 import * as Models from '../../models/index.js';
 import sequelizeConnection from '../../db/config.js';
 import { shuffle, unique } from '../helpers.js';
-import https from 'http';
 import axios from 'axios';
 
 import {

--- a/src/models/game.ts
+++ b/src/models/game.ts
@@ -141,21 +141,16 @@ class Game extends Model<InferAttributes<Game>, InferCreationAttributes<Game>> {
     const p2 = await players[1].player();
     const turnsNonce = this.turnNumber || 0;
     const currentPlayerTurn = (await this.turnGamePlayerNumber()) + 1;
-    console.log('pieces', pieces.tree.getRoot().toString());
-    console.log('arena', arena.tree.getRoot().toString());
-    console.log('p1', p1.minaPublicKey);
-    console.log('p2', p2.minaPublicKey);
-    console.log('turnsNonce', turnsNonce);
-    return new GameState(
-      pieces.tree.getRoot(),
-      arena.tree.getRoot(),
-      Field(currentPlayerTurn),
-      PublicKey.fromBase58(p1.minaPublicKey),
-      PublicKey.fromBase58(p2.minaPublicKey),
-      UInt32.from(550),
-      UInt32.from(650),
-      Field(turnsNonce)
-    );
+    return new GameState({
+      piecesRoot: pieces.tree.getRoot(),
+      arenaRoot: arena.tree.getRoot(),
+      playerTurn: Field(currentPlayerTurn),
+      player1PublicKey: PublicKey.fromBase58(p1.minaPublicKey),
+      player2PublicKey: PublicKey.fromBase58(p2.minaPublicKey),
+      arenaLength: UInt32.from(550),
+      arenaWidth: UInt32.from(650),
+      turnsNonce: Field(turnsNonce),
+    });
   }
 }
 

--- a/src/models/game.ts
+++ b/src/models/game.ts
@@ -140,7 +140,12 @@ class Game extends Model<InferAttributes<Game>, InferCreationAttributes<Game>> {
     const p1 = await players[0].player();
     const p2 = await players[1].player();
     const turnsNonce = this.turnNumber || 0;
-    const currentPlayerTurn = await this.turnGamePlayerNumber();
+    const currentPlayerTurn = (await this.turnGamePlayerNumber()) + 1;
+    console.log('pieces', pieces.tree.getRoot().toString());
+    console.log('arena', arena.tree.getRoot().toString());
+    console.log('p1', p1.minaPublicKey);
+    console.log('p2', p2.minaPublicKey);
+    console.log('turnsNonce', turnsNonce);
     return new GameState(
       pieces.tree.getRoot(),
       arena.tree.getRoot(),

--- a/src/models/game.ts
+++ b/src/models/game.ts
@@ -136,13 +136,9 @@ class Game extends Model<InferAttributes<Game>, InferCreationAttributes<Game>> {
   async toSnarkyGameState(): Promise<GameState> {
     const pieces = await serializePiecesTreeFromGameId(this.id);
     const arena = await serializeArenaTreeFromGameId(this.id);
-    const p1_id = this.turnPlayerOrder[0];
-    const p2_id = this.turnPlayerOrder[1];
-    if (!p1_id || !p2_id) {
-      throw new Error('Both players must be in the game');
-    }
-    const p1 = await (await Models.GamePlayer.findByPk(p1_id)).player();
-    const p2 = await (await Models.GamePlayer.findByPk(p2_id)).player();
+    const players = await this.gamePlayersInTurnOrder();
+    const p1 = await players[0].player();
+    const p2 = await players[1].player();
     const turnsNonce = this.turnNumber || 0;
     const currentPlayerTurn = await this.turnGamePlayerNumber();
     return new GameState(

--- a/src/models/game.ts
+++ b/src/models/game.ts
@@ -9,8 +9,8 @@ import sequelizeConnection from '../db/config.js';
 import { GamePhaseName } from './game_phase.js';
 import * as Models from './index.js';
 import { GameState } from 'mina-arena-contracts';
-import serializePiecesTree from '../service_objects/mina/pieces_tree_serializer.js';
-import serializeArenaTree from '../service_objects/mina/arena_tree_serializer.js';
+import { serializePiecesTreeFromGameId } from '../service_objects/mina/pieces_tree_serializer.js';
+import { serializeArenaTreeFromGameId } from '../service_objects/mina/arena_tree_serializer.js';
 import { Field, PublicKey, UInt32 } from 'snarkyjs';
 // import { ARENA_HEIGHT_U32, ARENA_WIDTH_U32 } from 'mina-arena-contracts';
 
@@ -134,8 +134,8 @@ class Game extends Model<InferAttributes<Game>, InferCreationAttributes<Game>> {
   }
 
   async toSnarkyGameState(): Promise<GameState> {
-    const pieces = await serializePiecesTree(this.id);
-    const arena = await serializeArenaTree(this.id);
+    const pieces = await serializePiecesTreeFromGameId(this.id);
+    const arena = await serializeArenaTreeFromGameId(this.id);
     const p1_id = this.turnPlayerOrder[0];
     const p2_id = this.turnPlayerOrder[1];
     if (!p1_id || !p2_id) {

--- a/src/models/game_piece.ts
+++ b/src/models/game_piece.ts
@@ -70,7 +70,7 @@ class GamePiece extends Model<
     return await (await this.playerUnit()).unit();
   }
 
-  async toSnarkyPiece(): Promise<Piece> {
+  async toSnarkyPiece(gamePieceNumber?: number): Promise<Piece> {
     const playerUnit = await this.playerUnit();
     const unit = await playerUnit.unit();
     const gamePlayer = await this.gamePlayer();
@@ -79,7 +79,10 @@ class GamePiece extends Model<
     const minaPublicKey = PublicKey.fromBase58(player.minaPublicKey);
 
     const snarkyPosition = Position.fromXY(this.positionX, this.positionY);
-    const gamePieceNumber = await this.gamePieceNumber();
+
+    if (!gamePieceNumber) {
+      gamePieceNumber = await this.gamePieceNumber();
+    }
 
     const pieceConditionJSON = { ...snarkyUnit.stats };
     pieceConditionJSON.health = UInt32.from(this.health);

--- a/src/service_objects/game_phase_resolver.ts
+++ b/src/service_objects/game_phase_resolver.ts
@@ -3,8 +3,8 @@ import sequelizeConnection from '../db/config.js';
 import resolveGamePieceAction from './game_piece_action_resolver.js';
 import { GamePhaseName, GAME_PHASE_ORDER } from '../models/game_phase.js';
 import { Transaction } from 'sequelize';
-import serializeArenaTree from './mina/arena_tree_serializer.js';
-import serializePiecesTree from './mina/pieces_tree_serializer.js';
+import { serializeArenaTreeFromGameId } from './mina/arena_tree_serializer.js';
+import { serializePiecesTreeFromGameId } from './mina/pieces_tree_serializer.js';
 
 export default async (
   gamePhase: Models.GamePhase,
@@ -23,11 +23,11 @@ export default async (
     order: [['id', 'ASC']],
     transaction,
   });
-  const startingPiecesMerleTree = await serializePiecesTree(
+  const startingPiecesMerleTree = await serializePiecesTreeFromGameId(
     game.id,
     transaction
   );
-  const startingArenaMerkleTree = await serializeArenaTree(
+  const startingArenaMerkleTree = await serializeArenaTreeFromGameId(
     game.id,
     transaction
   );

--- a/src/service_objects/game_piece_action_resolvers/melee_attack_resolver.ts
+++ b/src/service_objects/game_piece_action_resolvers/melee_attack_resolver.ts
@@ -4,12 +4,11 @@ import {
   EncrytpedAttackRoll,
   MELEE_ATTACK_RANGE,
   PiecesMerkleTree,
+  Action,
+  PhaseState,
 } from 'mina-arena-contracts';
 import resolveAttack from './attack_resolver.js';
 import { Transaction } from 'sequelize';
-import serializePiecesTree from '../mina/pieces_tree_serializer.js';
-import serializeArenaTree from '../mina/arena_tree_serializer.js';
-import { Action, PhaseState, DecrytpedAttackRoll } from 'mina-arena-contracts';
 import {
   Field,
   PublicKey,

--- a/src/service_objects/game_piece_action_resolvers/move_resolver.ts
+++ b/src/service_objects/game_piece_action_resolvers/move_resolver.ts
@@ -1,8 +1,6 @@
 import * as Models from '../../models/index.js';
 import { GamePieceCoordinates } from '../../graphql/__generated__/resolvers-types.js';
 import { Transaction } from 'sequelize';
-import serializePiecesTree from '../mina/pieces_tree_serializer.js';
-import serializeArenaTree from '../mina/arena_tree_serializer.js';
 import {
   Action,
   ArenaMerkleTree,

--- a/src/service_objects/game_piece_action_resolvers/ranged_attack_resolver.ts
+++ b/src/service_objects/game_piece_action_resolvers/ranged_attack_resolver.ts
@@ -1,8 +1,6 @@
 import * as Models from '../../models/index.js';
 import resolveAttack from './attack_resolver.js';
 import { Transaction } from 'sequelize';
-import serializePiecesTree from '../mina/pieces_tree_serializer.js';
-import serializeArenaTree from '../mina/arena_tree_serializer.js';
 import {
   Action,
   PhaseState,

--- a/src/service_objects/mina/arena_tree_serializer.ts
+++ b/src/service_objects/mina/arena_tree_serializer.ts
@@ -8,7 +8,7 @@ import { Transaction } from 'sequelize';
  * Given a Game ID, find all the GamePieces that are in the game and serialize them into an ArenaMerkleTree
  */
 
-export default async function serializeArenaTree(
+export async function serializeArenaTreeFromGameId(
   gameId: string | number,
   transaction?: Transaction
 ): Promise<ArenaMerkleTree> {

--- a/src/service_objects/mina/arena_tree_serializer.ts
+++ b/src/service_objects/mina/arena_tree_serializer.ts
@@ -31,3 +31,16 @@ export async function serializeArenaTreeFromGameId(
 
   return arenaTree;
 }
+
+export async function serializeArenaTreeFromPieces(
+  pieces: Array<Models.GamePiece>
+): Promise<ArenaMerkleTree> {
+  const arenaTree = new ArenaMerkleTree();
+  for (const gamePiece of pieces) {
+    const x = gamePiece.positionX;
+    const y = gamePiece.positionY;
+    arenaTree.set(x, y, Field(1));
+  }
+
+  return arenaTree;
+}

--- a/src/service_objects/mina/pieces_tree_serializer.ts
+++ b/src/service_objects/mina/pieces_tree_serializer.ts
@@ -14,7 +14,7 @@ import { Transaction } from 'sequelize';
  * Given a Game ID, find all of the Game Pieces and serialize them into a PiecesMerkleTree
  */
 
-export default async function serializePiecesTree(
+export async function serializePiecesTreeFromGameId(
   gameId: string | number,
   transaction?: Transaction
 ): Promise<PiecesMerkleTree> {

--- a/src/service_objects/mina/pieces_tree_serializer.ts
+++ b/src/service_objects/mina/pieces_tree_serializer.ts
@@ -36,3 +36,22 @@ export async function serializePiecesTreeFromGameId(
 
   return piecesTree;
 }
+
+export async function serializePiecesTreeFromPieces(
+  pieces: Array<Models.GamePiece>
+): Promise<PiecesMerkleTree> {
+  pieces = pieces.sort((a, b) => {
+    if (a.id > b.id) {
+      return -1;
+    } else {
+      return 1;
+    }
+  });
+  console.log(pieces);
+  const piecesTree = new PiecesMerkleTree();
+  for (let i = 0; i < pieces.length; i++) {
+    const snarkyPiece = await pieces[i].toSnarkyPiece(i + 1);
+    piecesTree.set(snarkyPiece.id.toBigInt(), snarkyPiece.hash());
+  }
+  return piecesTree;
+}

--- a/test/service_objects/game_piece_action_resolvers/move_resolver.test.ts
+++ b/test/service_objects/game_piece_action_resolvers/move_resolver.test.ts
@@ -213,6 +213,8 @@ describe('resolveMoveAction', () => {
         resolved: false,
         moveFrom: { x: currentPos.x, y: currentPos.y },
         moveTo: { x: currentPos.x + 5, y: currentPos.y },
+        gamePieceNumber: await movingGamePiece.gamePieceNumber(),
+        nonce: 1,
       },
       signature: signature.toJSON(),
     });

--- a/test/service_objects/mina/arena_tree_serializer.test.ts
+++ b/test/service_objects/mina/arena_tree_serializer.test.ts
@@ -1,7 +1,7 @@
 import * as Models from '../../../src/models';
 import * as Factories from '../../factories';
-import serializeArenaTree from '../../../src/service_objects/mina/arena_tree_serializer';
-import { ArenaMerkleTree, Position } from 'mina-arena-contracts';
+import { serializeArenaTreeFromGameId } from '../../../src/service_objects/mina/arena_tree_serializer';
+import { ArenaMerkleTree } from 'mina-arena-contracts';
 import { Field } from 'snarkyjs';
 
 describe('Arena Tree Serlializer', () => {
@@ -66,7 +66,7 @@ describe('Arena Tree Serlializer', () => {
       expectedTree.set(position[0], position[1], Field(1));
     });
 
-    const serializedTree = await serializeArenaTree(game.id);
+    const serializedTree = await serializeArenaTreeFromGameId(game.id);
 
     expect(serializedTree.tree.getRoot().toString()).toEqual(
       expectedTree.tree.getRoot().toString()

--- a/test/service_objects/mina/pieces_tree_serializer.test.ts
+++ b/test/service_objects/mina/pieces_tree_serializer.test.ts
@@ -1,14 +1,8 @@
 import * as Models from '../../../src/models';
 import * as Factories from '../../factories';
-import serializePiecesTree from '../../../src/service_objects/mina/pieces_tree_serializer';
-import {
-  PiecesMerkleTree,
-  Piece,
-  Position,
-  Unit,
-  UnitStats,
-} from 'mina-arena-contracts';
-import { Field, PublicKey, UInt32 } from 'snarkyjs';
+import { serializePiecesTreeFromGameId } from '../../../src/service_objects/mina/pieces_tree_serializer';
+import { PiecesMerkleTree, Piece, Position } from 'mina-arena-contracts';
+import { Field, PublicKey } from 'snarkyjs';
 
 describe('Pieces Tree Serlializer', () => {
   let game: Models.Game;
@@ -87,7 +81,7 @@ describe('Pieces Tree Serlializer', () => {
       expectedTree.set(BigInt(gamePieceNumber), snarkyPiece.hash());
     }
 
-    const serializedTree = await serializePiecesTree(game.id);
+    const serializedTree = await serializePiecesTreeFromGameId(game.id);
 
     expect(serializedTree.tree.getRoot().toString()).toEqual(
       expectedTree.tree.getRoot().toString()


### PR DESCRIPTION
Prime: @louiswheeleriv 

## Problem

Currently, we have snarkyJS code running for every game turn, which is verifying every signature and executing all the rules of the game.  It is not yet _generating a proof_ though.  The difference between generating a proof and executing the JS code is that no one can verify that we executed the JS code as we said, but the proof object is verifiable.

There will be many follow-up PRs, but this one aims to get us set up to start thinking about how to generate proofs for the game.

## Solution

We are adding JSON columns to the Game and Phase tables which will store the actual proof, but we will offload generation of the proof to a new repo I created ([Proof Worker](https://github.com/mina-arena/Proof-Worker)).  Compiling the circuit takes minutes, and proving stuff with the compiled circuits also takes minutes on my machine.  The idea of offloading it to the cloud is we can compile once and then we can make requests to it which should be markedly faster than a laptop.  I have yet to deploy it in the cloud.

This PR only addresses the `startGame` mutation, e.d. initializing a proof for the first time.  In the future, we will also read this proof JSON value and send it to the proof worker to apply a state transition.

