### PR TITLE
moving proof component into a signle tx

### DIFF
--- a/src/models/game_piece.ts
+++ b/src/models/game_piece.ts
@@ -70,7 +70,7 @@ class GamePiece extends Model<
     return await (await this.playerUnit()).unit();
   }
 
-  async toSnarkyPiece(): Promise<Piece> {
+  async toSnarkyPiece(gamePieceNumber?: number): Promise<Piece> {
     const playerUnit = await this.playerUnit();
     const unit = await playerUnit.unit();
     const gamePlayer = await this.gamePlayer();
@@ -79,7 +79,10 @@ class GamePiece extends Model<
     const minaPublicKey = PublicKey.fromBase58(player.minaPublicKey);
 
     const snarkyPosition = Position.fromXY(this.positionX, this.positionY);
-    const gamePieceNumber = await this.gamePieceNumber();
+
+    if (!gamePieceNumber) {
+      gamePieceNumber = await this.gamePieceNumber();
+    }
 
     const pieceConditionJSON = { ...snarkyUnit.stats };
     pieceConditionJSON.health = UInt32.from(this.health);

--- a/src/service_objects/mina/arena_tree_serializer.ts
+++ b/src/service_objects/mina/arena_tree_serializer.ts
@@ -31,3 +31,16 @@ export async function serializeArenaTreeFromGameId(
 
   return arenaTree;
 }
+
+export async function serializeArenaTreeFromPieces(
+  pieces: Array<Models.GamePiece>
+): Promise<ArenaMerkleTree> {
+  const arenaTree = new ArenaMerkleTree();
+  for (const gamePiece of pieces) {
+    const x = gamePiece.positionX;
+    const y = gamePiece.positionY;
+    arenaTree.set(x, y, Field(1));
+  }
+
+  return arenaTree;
+}

--- a/src/service_objects/mina/pieces_tree_serializer.ts
+++ b/src/service_objects/mina/pieces_tree_serializer.ts
@@ -36,3 +36,22 @@ export async function serializePiecesTreeFromGameId(
 
   return piecesTree;
 }
+
+export async function serializePiecesTreeFromPieces(
+  pieces: Array<Models.GamePiece>
+): Promise<PiecesMerkleTree> {
+  pieces = pieces.sort((a, b) => {
+    if (a.id > b.id) {
+      return -1;
+    } else {
+      return 1;
+    }
+  });
+  console.log(pieces);
+  const piecesTree = new PiecesMerkleTree();
+  for (let i = 0; i < pieces.length; i++) {
+    const snarkyPiece = await pieces[i].toSnarkyPiece(i + 1);
+    piecesTree.set(snarkyPiece.id.toBigInt(), snarkyPiece.hash());
+  }
+  return piecesTree;
+}

--- a/test/service_objects/game_piece_action_resolvers/move_resolver.test.ts
+++ b/test/service_objects/game_piece_action_resolvers/move_resolver.test.ts
@@ -213,6 +213,8 @@ describe('resolveMoveAction', () => {
         resolved: false,
         moveFrom: { x: currentPos.x, y: currentPos.y },
         moveTo: { x: currentPos.x + 5, y: currentPos.y },
+        gamePieceNumber: await movingGamePiece.gamePieceNumber(),
+        nonce: 1,
       },
       signature: signature.toJSON(),
     });

--- a/test/service_objects/mina/arena_tree_serializer.test.ts
+++ b/test/service_objects/mina/arena_tree_serializer.test.ts
@@ -1,7 +1,7 @@
 import * as Models from '../../../src/models';
 import * as Factories from '../../factories';
-import serializeArenaTree from '../../../src/service_objects/mina/arena_tree_serializer';
-import { ArenaMerkleTree, Position } from 'mina-arena-contracts';
+import { serializeArenaTreeFromGameId } from '../../../src/service_objects/mina/arena_tree_serializer';
+import { ArenaMerkleTree } from 'mina-arena-contracts';
 import { Field } from 'snarkyjs';
 
 describe('Arena Tree Serlializer', () => {
@@ -66,7 +66,7 @@ describe('Arena Tree Serlializer', () => {
       expectedTree.set(position[0], position[1], Field(1));
     });
 
-    const serializedTree = await serializeArenaTree(game.id);
+    const serializedTree = await serializeArenaTreeFromGameId(game.id);
 
     expect(serializedTree.tree.getRoot().toString()).toEqual(
       expectedTree.tree.getRoot().toString()

--- a/test/service_objects/mina/pieces_tree_serializer.test.ts
+++ b/test/service_objects/mina/pieces_tree_serializer.test.ts
@@ -1,14 +1,8 @@
 import * as Models from '../../../src/models';
 import * as Factories from '../../factories';
-import serializePiecesTree from '../../../src/service_objects/mina/pieces_tree_serializer';
-import {
-  PiecesMerkleTree,
-  Piece,
-  Position,
-  Unit,
-  UnitStats,
-} from 'mina-arena-contracts';
-import { Field, PublicKey, UInt32 } from 'snarkyjs';
+import { serializePiecesTreeFromGameId } from '../../../src/service_objects/mina/pieces_tree_serializer';
+import { PiecesMerkleTree, Piece, Position } from 'mina-arena-contracts';
+import { Field, PublicKey } from 'snarkyjs';
 
 describe('Pieces Tree Serlializer', () => {
   let game: Models.Game;
@@ -87,7 +81,7 @@ describe('Pieces Tree Serlializer', () => {
       expectedTree.set(BigInt(gamePieceNumber), snarkyPiece.hash());
     }
 
-    const serializedTree = await serializePiecesTree(game.id);
+    const serializedTree = await serializePiecesTreeFromGameId(game.id);
 
     expect(serializedTree.tree.getRoot().toString()).toEqual(
       expectedTree.tree.getRoot().toString()


### PR DESCRIPTION
I think this solves the problem I was having with ordering transactions.  In this version, the proof happens _before_ the game begins.  For now I'm not blocking anything on the result of the proof worker, but now that's an option.