### PR TITLE
Add gamesForPlayer query

### DIFF
--- a/src/graphql/__generated__/resolvers-types.ts
+++ b/src/graphql/__generated__/resolvers-types.ts
@@ -333,12 +333,18 @@ export type Query = {
   __typename?: 'Query';
   game?: Maybe<Game>;
   games: Array<Game>;
+  gamesForPlayer: Array<Game>;
   player?: Maybe<Player>;
   units: Array<Unit>;
 };
 
 export type QueryGameArgs = {
   id: Scalars['Int'];
+};
+
+export type QueryGamesForPlayerArgs = {
+  minaPublicKey: Scalars['String'];
+  statuses?: InputMaybe<Array<InputMaybe<GameStatus>>>;
 };
 
 export type QueryPlayerArgs = {
@@ -1059,6 +1065,12 @@ export type QueryResolvers<
     RequireFields<QueryGameArgs, 'id'>
   >;
   games?: Resolver<Array<ResolversTypes['Game']>, ParentType, ContextType>;
+  gamesForPlayer?: Resolver<
+    Array<ResolversTypes['Game']>,
+    ParentType,
+    ContextType,
+    RequireFields<QueryGamesForPlayerArgs, 'minaPublicKey'>
+  >;
   player?: Resolver<
     Maybe<ResolversTypes['Player']>,
     ParentType,

--- a/src/graphql/resolvers.ts
+++ b/src/graphql/resolvers.ts
@@ -1,8 +1,12 @@
-import { DiceRollInput, Resolvers } from './__generated__/resolvers-types';
+import {
+  DiceRollInput,
+  GameStatus,
+  Resolvers,
+} from './__generated__/resolvers-types';
 import * as Models from '../models/index.js';
 import * as Mutations from './mutations/index.js';
 
-import { camelToScreamingSnake } from './helpers.js';
+import { camelToScreamingSnake, snakeToCamel } from './helpers.js';
 import {
   GamePieceRangedAttackAction,
   GamePieceMeleeAttackAction,
@@ -12,6 +16,24 @@ const resolvers: Resolvers = {
   Query: {
     games: async (parent, args, contextValue, info): Promise<Models.Game[]> => {
       return await Models.Game.findAll();
+    },
+    gamesForPlayer: async (
+      parent,
+      args: { minaPublicKey: string; statuses?: GameStatus[] },
+      contextValue,
+      info
+    ): Promise<Models.Game[]> => {
+      const player = await Models.Player.findOne({
+        where: { minaPublicKey: args.minaPublicKey },
+      });
+      const gamePlayers = await Models.GamePlayer.findAll({
+        where: { playerId: player.id },
+      });
+      let queryFilter = { id: gamePlayers.map((gp) => gp.gameId) };
+      if (args.statuses && args.statuses.length > 0) {
+        queryFilter['status'] = args.statuses.map((s) => snakeToCamel(s));
+      }
+      return await Models.Game.findAll({ where: queryFilter });
     },
     game: async (
       parent,

--- a/src/graphql/schema.graphql
+++ b/src/graphql/schema.graphql
@@ -1,6 +1,7 @@
 type Query {
   game(id: Int!): Game
   games: [Game!]!
+  gamesForPlayer(minaPublicKey: String!, statuses: [GameStatus]): [Game!]!
   units: [Unit!]!
   player(minaPublicKey: String!): Player
 }


### PR DESCRIPTION
Prime @45930 

## Problem

We would like to list your currently in progress games on the `/sandbox` page. In order to do so, we will need the ability to list games which contain a particular player (you).

## Solution

Add a `gamesForPlayer` field to the GraphQL schema which allows you to fetch `Games` which contain a particular player, given that player's mina public key. Optionally, a list of statuses can be provided to filter for games in particular statuses.

![Screen Shot 2023-07-27 at 7 14 15 PM](https://github.com/mina-arena/mina-arena-server/assets/8811423/215c0bdd-58de-49cf-974c-61eec5d9f73d)

![Screen Shot 2023-07-27 at 7 14 25 PM](https://github.com/mina-arena/mina-arena-server/assets/8811423/5a4c97f8-75ba-428e-b852-0943f8c8ea62)
