### PR TITLE
Fix fetching games for new player

### DIFF
--- a/src/graphql/resolvers.ts
+++ b/src/graphql/resolvers.ts
@@ -26,6 +26,7 @@ const resolvers: Resolvers = {
       const player = await Models.Player.findOne({
         where: { minaPublicKey: args.minaPublicKey },
       });
+      if (!player) return [];
       const gamePlayers = await Models.GamePlayer.findAll({
         where: { playerId: player.id },
       });


### PR DESCRIPTION
Prime @45930 

## Problem

I noticed the following bug when testing on prod:
- I generated a new keypair
- I went to the Play page which displays my in progress games or allows me to start a new game
- The in progress games table never loads, and an error is shown in the dev console
  - This is because when we try to fetch in progress games, we assume a `Player` record exists for your provided public key. In this case, no `Player` record exists because it gets created when I start a game, and I haven't done that yet with this newly generated key.

![Screen Shot 2023-07-29 at 1 15 01 PM](https://github.com/mina-arena/mina-arena-server/assets/8811423/920cf3e6-2fcd-411a-bd8f-f1ad194010d0)


## Solution

Just return `[]` for the `gamesForPlayer` query if no `Player` record exists for the provided public key.

![Screen Shot 2023-07-29 at 1 15 10 PM](https://github.com/mina-arena/mina-arena-server/assets/8811423/966f4e89-dd6d-4bec-86ba-b85e7cdc6509)


## Notes
